### PR TITLE
Lightly customise the default datepicker

### DIFF
--- a/src/components/Datepicker/Datepicker.scss
+++ b/src/components/Datepicker/Datepicker.scss
@@ -1,0 +1,10 @@
+@import '/src/styles/common.scss';
+
+.rdp-root {
+  --rdp-accent-color: #{$grey900}; // chevron etc.
+  --rdp-today-color: #{$grey900}; // today's date
+}
+
+.rdp-today {
+  font-weight: 900;
+}

--- a/src/components/Datepicker/index.tsx
+++ b/src/components/Datepicker/index.tsx
@@ -1,48 +1,21 @@
 import { fi } from 'date-fns/locale';
-import {
-  DayPicker,
-  getDefaultClassNames,
-  type ClassNames,
-} from 'react-day-picker';
+import { DayPicker } from 'react-day-picker';
 import type { DateRange, DayPickerSingleProps } from 'react-day-picker';
+import 'react-day-picker/dist/style.css';
+
+import './Datepicker.scss';
 
 export type { DateRange, DayPickerSingleProps };
 
 export type DatepickerProps = React.ComponentPropsWithoutRef<typeof DayPicker>;
 
-/**
- * Uses tailwind classes for styling
- */
-const defaultClassNames = getDefaultClassNames();
-
-export const classNames: ClassNames = {
-  ...defaultClassNames,
-  root: 'text-gray-800',
-  months: 'flex gap-4 relative px-4',
-  month_caption: 'flex justify-center items-center h-10',
-  dropdowns: 'flex gap-2',
-  button_previous:
-    'inline-flex justify-center items-center absolute top-0 left-0 w-10 h-10 rounded-full text-gray-600 hover:bg-gray-100',
-  button_next:
-    'inline-flex justify-center items-center absolute top-0 right-0 w-10 h-10 rounded-full text-gray-600 hover:bg-gray-100',
-  month_grid: 'border-collapse border-spacing-0',
-  weekday: 'w-10 h-10 uppercase align-middle text-center',
-  day: 'w-10 h-10 align-middle text-center border-0 px-0 rounded-full transition-colors hover:bg-sky-100 focus:outline-none focus-visible:ring focus-visible:ring-sky-300 focus-visible:ring-opacity-50 active:bg-sky-600 active:text-white',
-  selected: 'text-white bg-sky-500 hover:bg-sky-500',
-  today: 'font-bold',
-  disabled: 'opacity-25 hover:bg-white active:bg-white active:text-gray-800',
-  outside: 'enabled:opacity-50',
-  range_middle: 'rounded-none',
-  range_end: 'rounded-l-none rounded-r-full',
-  range_start: 'rounded-r-none rounded-l-full',
-  hidden: 'hidden',
-};
-
 export const Datepicker = (props: DatepickerProps) => (
   <DayPicker
     captionLayout="dropdown"
     locale={fi}
-    classNames={classNames}
+    modifiersClassNames={{
+      today: 'rdp-today',
+    }}
     {...props}
   />
 );


### PR DESCRIPTION
Ei oo ihan samannäköinen kuin aikaisemmin, mutta aika lähellä aika pienillä kustomoinneilla.

Vanha: 
<img width="1296" height="1810" alt="Screenshot 2025-07-31 at 13-51-35 Component Library" src="https://github.com/user-attachments/assets/aa06a3e1-7965-41be-93a7-68d978202295" />

Uusi:
<img width="1207" height="1201" alt="Screenshot 2025-08-05 at 12 55 45" src="https://github.com/user-attachments/assets/f027968c-4f9b-4c72-bacd-3822007632a1" />
