### PR TITLE
Update CI to Node 22 and drop bahmutov/npm-install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,12 +24,11 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 22
+          cache: 'npm'
 
-      - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
-        with:
-          useLockFile: false
+      - name: 📥 Install deps
+        run: npm install
 
       - name: 🔎 Type check
         run: npm run typecheck --if-present
@@ -50,12 +49,11 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 22
+          cache: 'npm'
 
-      - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
-        with:
-          useLockFile: false
+      - name: 📥 Install deps
+        run: npm install
 
       - name: ⚡ Run vitest
         run: npm run test -- --coverage


### PR DESCRIPTION
## Summary

- Bumps `node-version` from 18 (EOL since April 2025) to 22 (current LTS)
- Replaces `bahmutov/npm-install@v1` with plain `npm install`, using `actions/setup-node`'s built-in `cache: 'npm'` for dependency caching — one fewer third-party action to maintain

## Test plan
- [x] CI typecheck and vitest jobs pass with Node 22
- [x] Dependency caching works via `actions/setup-node` cache hit on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)