### PR TITLE
Capitalize standaloneCategory text

### DIFF
--- a/src/components/Heading/Heading.module.scss
+++ b/src/components/Heading/Heading.module.scss
@@ -209,6 +209,7 @@
 
 .standaloneCategory {
   @include headingBlackSm;
+  text-transform: capitalize;
   color: var(--brandCategoryColor);
   margin-bottom: $spacingMd;
   background-color: $white;


### PR DESCRIPTION
Tagit tulee joskus pienellä alkukirjaimella – tämä yhdenmukaistaa tagien ja kategorioiden muotoilun.