### PR TITLE
Match backdrop gradient height to text height

### DIFF
--- a/src/components/Teaser/Teaser.module.scss
+++ b/src/components/Teaser/Teaser.module.scss
@@ -252,6 +252,15 @@
     align-items: center;
     text-align: center;
     padding: $spacingSm;
+    height: auto;
+    top: unset;
+    bottom: 0;
+    background: linear-gradient(
+      to top,
+      #1b1b1b 0%,
+      #1b1b1b82 60%,
+      transparent 100%
+    );
 
     @media (min-width: $smallDesktopLowerLimit) {
       padding: $spacingMd;


### PR DESCRIPTION
ENNEN:
<img width="676" height="1115" alt="image" src="https://github.com/user-attachments/assets/d9cd2475-a64d-44a5-a92a-ccb9f1f944c7" />

JÄLKEEN:
<img width="676" height="1118" alt="image" src="https://github.com/user-attachments/assets/01fed7b7-1df6-4623-b915-9846055d8460" />
