### PR TITLE
Fix customer service hours in ViestimediaFooter: 8-21 -> 8-18

### DIFF
--- a/src/components/ViestimediaFooter/ViestimediaFooter.tsx
+++ b/src/components/ViestimediaFooter/ViestimediaFooter.tsx
@@ -31,7 +31,7 @@ export const ViestimediaFooter = ({ seoText }: Props) => {
         },
         main: {
           infoTexts: [
-            'Puh. 020 413 2277 ma-pe klo 8-21, hinta mpm/pvm',
+            'Puh. 020 413 2277 ma-pe klo 8-18, hinta mpm/pvm',
             ...(seoText ? [seoText] : []),
           ],
         },


### PR DESCRIPTION
## Summary
- Updates customer service phone hours in `ViestimediaFooter` from `8-21` to `8-18`

VM-6004

## Test plan
- [ ] Verify subscription page footer shows "Puh. 020 413 2277 ma-pe klo 8-18, hinta mpm/pvm"