### PR TITLE
revert: eslint-plugin-react-refresh bump to ^0.5.0 (breaks eslint 8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "classnames": "^2.3.2",
     "eslint": "^8.44.0",
     "eslint-plugin-react-hooks": "^7.0.0",
-    "eslint-plugin-react-refresh": "^0.5.0",
+    "eslint-plugin-react-refresh": "^0.4.1",
     "happy-dom": "^20.0.0",
     "postcss": "^8.4.26",
     "prettier": "^3.0.2",


### PR DESCRIPTION
## Problem

PR #213 bumped `eslint-plugin-react-refresh` from `^0.4.x` to `^0.5.0`. Version 0.5.x changed its peer dependency to require `eslint ^9 || ^10`, but this repo uses `eslint@^8.44.0`.

This broke CI immediately after merge:

```
npm error ERESOLVE unable to resolve dependency tree
npm error peer eslint@"^9 || ^10" from eslint-plugin-react-refresh@0.5.2
npm error   dev eslint-plugin-react-refresh@"^0.5.0" from the root project
```

## Fix

Reverts the `eslint-plugin-react-refresh` version back to `^0.4.x` range.

To get 0.5.x, first upgrade eslint to v9 or v10 separately.