### PR TITLE
VM-6062: Remove Suomen Parhaat brand references

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1265,12 +1265,6 @@ function GeneralRoute() {
           <Heading
             level="h2"
             style={HeadingStyle.Subheading}
-            text="Suomen Parhaat subheading"
-            className="suomenParhaat"
-          />
-          <Heading
-            level="h2"
-            style={HeadingStyle.Subheading}
             text="Native Ad subheading"
             className="nativeAd"
           />

--- a/src/components/Heading/Heading.module.scss
+++ b/src/components/Heading/Heading.module.scss
@@ -265,8 +265,7 @@
   }
 }
 
-.nativeAd,
-.suomenParhaat {
+.nativeAd {
   &.teaserXl,
   &.teaserL,
   &.teaserM,


### PR DESCRIPTION
## Summary
- Removes `.suomenParhaat` CSS class from `Heading.module.scss` (Suomen Parhaat was sharing styles with `.nativeAd` — `.nativeAd` remains unchanged)
- Removes the Suomen Parhaat demo heading from `App.tsx`

Suomen Parhaat has been retired as a product so all references are no longer needed.

## Test plan
- [ ] Verify Heading component renders correctly for remaining variants
- [ ] Confirm no visual regressions on nativeAd-styled headings