### PR TITLE
Update react-day-picker to v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "date-fns": "4.4.0",
         "focus-trap-react": "^12.0.3",
         "input-range-scss": "^2.0.0",
-        "react-day-picker": "^9.8.0",
+        "react-day-picker": "^10.0.1",
         "react-player": "^3.4.0",
         "screenfull": "^6.0.2",
         "vite-plugin-svgr": "^5.2.0"
@@ -1354,15 +1354,6 @@
         "@svta/cml-utils": "1.0.1"
       }
     },
-    "node_modules/@tabby_ai/hijri-converter": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
-      "integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
@@ -2572,12 +2563,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
       }
-    },
-    "node_modules/date-fns-jalali": {
-      "version": "4.1.0-0",
-      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
-      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
-      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -4689,15 +4674,13 @@
       }
     },
     "node_modules/react-day-picker": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
-      "integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-10.0.1.tgz",
+      "integrity": "sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==",
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "^1.4.1",
-        "@tabby_ai/hijri-converter": "1.0.5",
-        "date-fns": "^4.1.0",
-        "date-fns-jalali": "4.1.0-0"
+        "date-fns": "^4.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -4707,7 +4690,13 @@
         "url": "https://github.com/sponsors/gpbl"
       },
       "peerDependencies": {
+        "@types/react": ">=16.8.0",
         "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "date-fns": "4.4.0",
     "focus-trap-react": "^12.0.3",
     "input-range-scss": "^2.0.0",
-    "react-day-picker": "^9.8.0",
+    "react-day-picker": "^10.0.1",
     "react-player": "^3.4.0",
     "screenfull": "^6.0.2",
     "vite-plugin-svgr": "^5.2.0"

--- a/src/components/Datepicker/index.tsx
+++ b/src/components/Datepicker/index.tsx
@@ -1,11 +1,21 @@
 import { fi } from 'date-fns/locale';
 import { DayPicker } from 'react-day-picker';
-import type { DateRange, DayPickerSingleProps } from 'react-day-picker';
-import 'react-day-picker/dist/style.css';
+import type {
+  DateRange,
+  PropsBase,
+  PropsSingle,
+  PropsSingleRequired,
+} from 'react-day-picker';
+import 'react-day-picker/style.css';
 
 import './Datepicker.scss';
 
-export type { DateRange, DayPickerSingleProps };
+export type { DateRange };
+
+// `DayPickerSingleProps` was removed in react-day-picker v10; this
+// reconstructs the equivalent (base props + single-selection mode props).
+export type DayPickerSingleProps = PropsBase &
+  (PropsSingle | PropsSingleRequired);
 
 export type DatepickerProps = React.ComponentPropsWithoutRef<typeof DayPicker>;
 


### PR DESCRIPTION
Major bump: react-day-picker ^9.8.0 -> ^10.0.0.

Breaking changes handled:
- `DayPickerSingleProps` was removed from react-day-picker's public exports in v10; reconstructed locally in src/components/Datepicker/index.tsx from the new exported building blocks so clib keeps exporting the same type/shape for consumers.
- Stylesheet import updated: react-day-picker/dist/style.css -> react-day-picker/style.css.

Worth noting for reviewers: v10 changes the default `navLayout` to "after". Neither Datepicker nor InputDatePicker set navLayout explicitly, so consumers will see a visual shift in prev/next button placement unless we decide to pin the old layout explicitly.

Part of VM-6146/VM-6203. Version/tag is applied manually via the release workflow after merge (major).