### PR TITLE
Fix FocusTrap import for focus-trap-react v12 (already shipped in v8.0.0)

### DIFF
--- a/src/components/InputDatePicker/InputDatePicker.tsx
+++ b/src/components/InputDatePicker/InputDatePicker.tsx
@@ -3,7 +3,7 @@ import styles from './InputDatePicker.module.scss';
 import EventIcon from 'assets/icons/event-outlined.svg?react';
 import { Input } from 'components/Input/Input';
 import { format } from 'date-fns';
-import FocusTrap from 'focus-trap-react';
+import { FocusTrap } from 'focus-trap-react';
 import {
   useFloating,
   autoUpdate,


### PR DESCRIPTION
focus-trap-react was bumped to ^12.0.3 on main already — it landed accidentally inside PR #272 (which was supposed to bump vite-plugin-svgr instead, but shipped this dependency change by mistake; see separate PR for the real vite-plugin-svgr v5 bump).

Since the version bump is already live in the released v8.0.0, this PR now only carries the code fix that should have shipped with it: focus-trap-react v11+ deprecated the default export in favor of a named export. Switched `import FocusTrap from 'focus-trap-react'` to `import { FocusTrap } from 'focus-trap-react'` in InputDatePicker.tsx.

typecheck/lint/test all green against current main.

Part of VM-6146/VM-6203.