### PR TITLE
Update actions/checkout and actions/setup-node to v7

### DIFF
--- a/.github/workflows/generate-tag-and-release.yml
+++ b/.github/workflows/generate-tag-and-release.yml
@@ -23,7 +23,7 @@ jobs:
       new_tag: ${{ steps.collect.outputs.new_tag }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Configure git
         run: |
@@ -31,7 +31,7 @@ jobs:
           git config user.email github-actions@github.com
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 
@@ -55,7 +55,7 @@ jobs:
     needs: version
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Create release notes
         id: notes
@@ -79,10 +79,10 @@ jobs:
     needs: release
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://npm.pkg.github.com

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,10 +20,10 @@ jobs:
         uses: styfle/cancel-workflow-action@0.13.1
 
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: ⎔ Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: 'npm'
@@ -46,10 +46,10 @@ jobs:
         uses: styfle/cancel-workflow-action@0.13.1
 
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: ⎔ Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: 'npm'
@@ -69,10 +69,10 @@ jobs:
         uses: styfle/cancel-workflow-action@0.13.1
 
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: ⎔ Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: 'npm'


### PR DESCRIPTION
CI-only: actions/checkout v6->v7, actions/setup-node v6->v7 across .github/workflows/*.yml. No npm changes, no clib version bump (nothing published changes).

Part of VM-6146.