### PR TITLE
Update vite-plugin-svgr to v5 (redo of #272)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "react-day-picker": "^9.8.0",
         "react-player": "^3.4.0",
         "screenfull": "^6.0.2",
-        "vite-plugin-svgr": "^4.0.0"
+        "vite-plugin-svgr": "^5.2.0"
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",
@@ -8056,17 +8056,17 @@
       }
     },
     "node_modules/vite-plugin-svgr": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-4.5.0.tgz",
-      "integrity": "sha512-W+uoSpmVkSmNOGPSsDCWVW/DDAyv+9fap9AZXBvWiQqrboJ08j2vh0tFxTD/LjwqwAd3yYSVJgm54S/1GhbdnA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-5.2.0.tgz",
+      "integrity": "sha512-qj2eAKF8C6PZWemVTvQA0xgQIcP1hHU6Buh7fl6BhvayWwnuxE+z417miKxeDvRWbDrupQ1oK99hfxElopJ3sQ==",
       "license": "MIT",
       "dependencies": {
-        "@rollup/pluginutils": "^5.2.0",
+        "@rollup/pluginutils": "^5.3.0",
         "@svgr/core": "^8.1.0",
         "@svgr/plugin-jsx": "^8.1.0"
       },
       "peerDependencies": {
-        "vite": ">=2.6.0"
+        "vite": ">=3.0.0"
       }
     },
     "node_modules/vite-tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-day-picker": "^9.8.0",
     "react-player": "^3.4.0",
     "screenfull": "^6.0.2",
-    "vite-plugin-svgr": "^4.0.0"
+    "vite-plugin-svgr": "^5.2.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",


### PR DESCRIPTION
PR #272 was titled/reviewed as this bump but actually shipped a `focus-trap-react` version change instead (likely cross-worktree contamination during the original batch work) — it's already merged and released as part of v8.0.0, so `focus-trap-react` is live at ^12.0.3 there while `vite-plugin-svgr` never actually moved off ^4.0.0. See #275 for the accompanying import fix that focus-trap-react v12 needed and didn't get.

This PR does the vite-plugin-svgr bump that was originally intended: ^4.0.0 -> ^5.2.0. No breaking changes applicable (v5 only drops Vite 2 support, clib is on Vite 6+). typecheck/lint/test/build all green.

Part of VM-6146/VM-6203.