### PR TITLE
Hotfix: revert typescript to v5.9.3 (main is currently unbuildable)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "react-use": "^17.4.0",
         "sass": "^1.63.6",
         "tailwindcss": "^3.3.3",
-        "typescript": "^6.0.3",
+        "typescript": "^5.9.3",
         "vite": "^6.0.0",
         "vite-plugin-dts": "^5.0.0",
         "vite-tsconfig-paths": "^6.1.1",
@@ -6937,9 +6937,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7340,22 +7340,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/vite/node_modules/fdir": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-use": "^17.4.0",
     "sass": "^1.63.6",
     "tailwindcss": "^3.3.3",
-    "typescript": "^6.0.3",
+    "typescript": "^5.9.3",
     "vite": "^6.0.0",
     "vite-plugin-dts": "^5.0.0",
     "vite-tsconfig-paths": "^6.1.1",


### PR DESCRIPTION
**Main is currently broken.** #284 bumped typescript to ^6.0.3, which has a real regression: it fails to auto-discover @types/* packages under node_modules/@types in this project's config. Every Node built-in module import breaks — e.g. `import { UrlObject } from 'url'` in Link.tsx — and `npm run build` (tsc && vite build) fails with exit code 2 on main right now.

Verified rigorously, not just observed once:
- Isolated minimal reproduction outside this repo, bisected setting-by-setting.
- `tsc --listFilesOnly` shows **zero** @types/node files loaded into the program under 6.0.3, vs dozens under 5.9.3, with the byte-identical tsconfig and node_modules in the same directory — only the tsc binary swapped.
- 6.0.3 is the latest published 6.0.x; no patch exists yet that fixes this.

This reverts just the `typescript` version to ^5.9.3 (latest working 5.x, not the original ^5.0.2 — no reason to go back further than necessary). Keeps the tsconfig.json modernization from #284 (baseUrl removal, explicit path aliases) since that part was correct and still needed for whenever TS 6/7 becomes viable again.

typecheck/lint/test/build all green.

Part of VM-6146/VM-6203.