### PR TITLE
VM-5746: Fall back gracefully when a Teaser image fails to load

### DIFF
--- a/src/components/Teaser/Teaser.module.scss
+++ b/src/components/Teaser/Teaser.module.scss
@@ -291,6 +291,20 @@
     padding: $spacingSm;
     background: linear-gradient(to top, #1b1b1b 0%, #1b1b1b00 60%);
   }
+
+  // Unlike .compact/.machine/etc., .carousel has no background of its own —
+  // its text is only legible layered over the image. Fall back to a plain
+  // card (static layout, default text color) when the image is missing or
+  // failed to load (see Teaser.tsx's noImage handling), instead of leaving
+  // invisible white-on-white text.
+  &.noImage {
+    .articleInfo {
+      position: static;
+      height: auto;
+      background: none;
+      color: $fontColor;
+    }
+  }
 }
 
 .machine {

--- a/src/components/Teaser/Teaser.test.tsx
+++ b/src/components/Teaser/Teaser.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Teaser, TeaserType } from './Teaser';
+
+describe('Teaser', () => {
+  it('keeps the image when it loads successfully', () => {
+    const { container } = render(
+      <Teaser
+        id="1"
+        heading="Test heading"
+        linkUrl="/test"
+        teaserType={TeaserType.Carousel}
+        image={<img src="https://example.com/ok.jpg" alt="" />}
+      />
+    );
+
+    expect(container.querySelector('img')).toBeInTheDocument();
+    expect(container.firstChild).not.toHaveClass('vmTeaser__noImage');
+  });
+
+  it('removes the image and falls back to noImage styling when it fails to load', () => {
+    const { container } = render(
+      <Teaser
+        id="2"
+        heading="Test heading"
+        linkUrl="/test"
+        teaserType={TeaserType.Carousel}
+        image={<img src="https://example.com/broken.jpg" alt="" />}
+      />
+    );
+
+    const img = container.querySelector('img');
+    expect(img).toBeInTheDocument();
+
+    // The 'error' event on <img> doesn't bubble — this only passes if
+    // Teaser is listening on the capture phase (onErrorCapture), not the
+    // bubble phase (onError), which is the whole point of the fix.
+    fireEvent.error(img!);
+
+    expect(container.querySelector('img')).not.toBeInTheDocument();
+    expect(screen.getByText('Test heading')).toBeInTheDocument();
+    expect(container.firstChild).toHaveClass('vmTeaser__noImage');
+  });
+
+  it('falls back to noImage styling on image error for TeaserType.Topic too', () => {
+    const { container } = render(
+      <Teaser
+        id="3"
+        heading="Topic heading"
+        linkUrl="/test"
+        teaserType={TeaserType.Topic}
+        image={<img src="https://example.com/broken.jpg" alt="" />}
+      />
+    );
+
+    fireEvent.error(container.querySelector('img')!);
+
+    expect(container.querySelector('img')).not.toBeInTheDocument();
+    expect(container.firstChild).toHaveClass('vmTeaser__noImage');
+  });
+
+  it('renders without an image as noImage from the start', () => {
+    const { container } = render(
+      <Teaser
+        id="4"
+        heading="Test heading"
+        linkUrl="/test"
+        teaserType={TeaserType.Carousel}
+      />
+    );
+
+    expect(container.querySelector('img')).not.toBeInTheDocument();
+    expect(container.firstChild).toHaveClass('vmTeaser__noImage');
+  });
+});

--- a/src/components/Teaser/Teaser.test.tsx
+++ b/src/components/Teaser/Teaser.test.tsx
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { Teaser, TeaserType } from './Teaser';
+// Assert against the real generated class, not a guessed literal string —
+// the scoped-name format differs between local `vite build` and the
+// vitest/CI CSS pipeline.
+import styles from './Teaser.module.scss';
 
 describe('Teaser', () => {
   it('keeps the image when it loads successfully', () => {
@@ -15,7 +19,7 @@ describe('Teaser', () => {
     );
 
     expect(container.querySelector('img')).toBeInTheDocument();
-    expect(container.firstChild).not.toHaveClass('vmTeaser__noImage');
+    expect(container.firstChild).not.toHaveClass(styles.noImage);
   });
 
   it('removes the image and falls back to noImage styling when it fails to load', () => {
@@ -39,7 +43,7 @@ describe('Teaser', () => {
 
     expect(container.querySelector('img')).not.toBeInTheDocument();
     expect(screen.getByText('Test heading')).toBeInTheDocument();
-    expect(container.firstChild).toHaveClass('vmTeaser__noImage');
+    expect(container.firstChild).toHaveClass(styles.noImage);
   });
 
   it('falls back to noImage styling on image error for TeaserType.Topic too', () => {
@@ -56,7 +60,7 @@ describe('Teaser', () => {
     fireEvent.error(container.querySelector('img')!);
 
     expect(container.querySelector('img')).not.toBeInTheDocument();
-    expect(container.firstChild).toHaveClass('vmTeaser__noImage');
+    expect(container.firstChild).toHaveClass(styles.noImage);
   });
 
   it('renders without an image as noImage from the start', () => {
@@ -70,6 +74,6 @@ describe('Teaser', () => {
     );
 
     expect(container.querySelector('img')).not.toBeInTheDocument();
-    expect(container.firstChild).toHaveClass('vmTeaser__noImage');
+    expect(container.firstChild).toHaveClass(styles.noImage);
   });
 });

--- a/src/components/Teaser/Teaser.tsx
+++ b/src/components/Teaser/Teaser.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useState } from 'react';
 import classNames from 'classnames';
 import styles from './Teaser.module.scss';
 import { Heading, TopicHeading } from 'components/Heading/Heading';
@@ -6,6 +7,19 @@ import ClockIcon from 'assets/icons/clock.svg?react';
 import { TeaserType, TeaserHeadingMap } from './Teaser.types';
 
 export { TeaserType, TeaserHeadingMap };
+
+// `image` is an opaque element the consumer renders (an <img>, ImageElement,
+// a Next <Image>, ...) — Teaser doesn't control its internals, so it can't
+// know up front whether the image will actually load. The `error` event on
+// <img> doesn't bubble, but it does still traverse the capture phase, so a
+// capture-phase listener on an ancestor sees it even though a bubble-phase
+// listener there never would. Once an image fails, treat the teaser as if
+// no image had been passed at all, for every teaser type.
+const useImageLoadFailed = () => {
+  const [failed, setFailed] = useState(false);
+  const onErrorCapture = useCallback(() => setFailed(true), []);
+  return [failed, onErrorCapture] as const;
+};
 
 type Props = {
   id: string;
@@ -76,10 +90,13 @@ const TeaserTopic = ({
   className = '',
   onClick,
 }: TeaserTopicProps) => {
+  const [imageFailed, onImageErrorCapture] = useImageLoadFailed();
+  const hasImage = Boolean(image) && !imageFailed;
+
   const moduleExtend = styles[className] ? true : false;
   const rootClassName = classNames(styles.teaserContainer, {
     [styles[TeaserType.Topic]]: true,
-    [styles.noImage]: Boolean(!image),
+    [styles.noImage]: !hasImage,
     [styles[className]]: moduleExtend,
     [className]: !moduleExtend,
   });
@@ -93,7 +110,14 @@ const TeaserTopic = ({
         data-analytics-name="teaser-link"
         onClick={onClick}
       >
-        {image && <div className={styles.articleImage}>{image}</div>}
+        {hasImage && (
+          <div
+            className={styles.articleImage}
+            onErrorCapture={onImageErrorCapture}
+          >
+            {image}
+          </div>
+        )}
         <div className={styles.articleInfo}>
           <div className={styles.heading}>
             <TopicHeading
@@ -129,10 +153,13 @@ const TeaserDefault = ({
   className = '',
   onClick,
 }: Props) => {
+  const [imageFailed, onImageErrorCapture] = useImageLoadFailed();
+  const hasImage = Boolean(image) && !imageFailed;
+
   const moduleExtend = styles[className] ? true : false;
   const containerClassName = classNames(styles.teaserContainer, {
     [styles[teaserType]]: true,
-    [styles.noImage]: Boolean(!image),
+    [styles.noImage]: !hasImage,
     [styles.hasButtons]: Boolean(buttons),
     [styles[className]]: moduleExtend,
     [className]: !moduleExtend,
@@ -149,7 +176,14 @@ const TeaserDefault = ({
         onClick={onClick}
       >
         {topBanner && <div className={styles.banner}>{topBanner}</div>}
-        {image && <div className={styles.articleImage}>{image}</div>}
+        {hasImage && (
+          <div
+            className={styles.articleImage}
+            onErrorCapture={onImageErrorCapture}
+          >
+            {image}
+          </div>
+        )}
         {author && <div className={styles.authorContainer}>{author}</div>}
         {rankNumber && <div className={styles.rankNumber}>{rankNumber}</div>}
         <div className={styles.articleInfo}>


### PR DESCRIPTION
## Summary
- `Teaser` only knew whether an `image` prop was *passed*, not whether it actually loaded. Images are served from imgix and any of them can 404 at runtime — not specific to one vertical — so this affects every consumer, not just one teaser type.
- Added a shared `useImageLoadFailed` hook: tracks load failure via `onErrorCapture` on the wrapper around `image` (the `<img>` `error` event doesn't bubble, but it does traverse the capture phase). A failed image is now treated the same as a missing one, for every `TeaserType`.
- Most teaser types already degrade fine without an image — `.noImage` already collapses the image column and text stays the normal (dark) color there. Only `TeaserType.Carousel` needed a CSS fallback: its heading is white text with no background of its own (only legible layered over the image), so a missing/failed image left invisible white-on-white text. Added `.carousel.noImage` to fall back to a plain card. `.backgroundImage`/`.topic` weren't touched — their gradients are already positioned correctly behind the text regardless of whether the image loads.
- Added `Teaser.test.tsx` covering: image loads fine, image load fails (verifies via `fireEvent.error`, which only passes with a capture-phase listener), `TeaserType.Topic` gets the same fallback, and no-image-from-the-start still works.

## Context
Surfaced from vm-web's konedata "most viewed machines" carousel (VM-5746), where machine images come from the Konedata API and can 404. That PR (https://github.com/viestimedia/vm-web/pull/2645) originally special-cased the fallback at the call site, then reverted that workaround back to plain `Teaser` + `ImageElement` in favor of this fix — so **that PR is currently blocked on this one**: it doesn't actually fix anything again until `@viestimedia/clib` is bumped to a version containing this change (merge + manual `npm publish`), and its `package.json`/`package-lock.json` are updated accordingly.

## Test plan
- [x] `npm run typecheck` (pre-existing, unrelated failure in `InputDatePicker.tsx` confirmed present on `main` too)
- [x] `npx eslint src/components/Teaser --max-warnings 0`
- [ ] `npm run test` — attempted locally but the sandbox's vitest run was too slow to complete even for an unrelated pre-existing test file (looks like a cold esbuild/vite-plugin-dts build in this environment, not something caused by this change); please run CI/local `npm run test -- --run src/components/Teaser` to confirm