### PR TITLE
Fix the require() fix: source transform instead of a Node-only shim

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,25 @@ export default defineConfig({
     svgr({
       exportAsDefault: true,
     }),
+    {
+      // focus-trap-react is plain CJS and does `require('react')` in its own
+      // source to read React.version. 'react' is external here, and rolldown's
+      // fallback for a require() targeting an external only works if a global
+      // `require` exists at runtime - true in Node's CJS mode, but not under
+      // native ESM loaders (Vitest) or in the browser (Next.js/webpack), where
+      // it either throws or fails to statically resolve. Converting this one
+      // known require() call to a real import at the source level means
+      // rolldown never needs that fallback for it at all.
+      name: 'focus-trap-react-require-to-import',
+      transform(code, id) {
+        if (!id.includes('/focus-trap-react/')) return null;
+        if (!code.includes("require('react')")) return null;
+        return code.replace(
+          "var React = require('react');",
+          "import React from 'react';"
+        );
+      },
+    },
   ],
 
   test: {
@@ -75,15 +94,6 @@ export default defineConfig({
     },
     rolldownOptions: {
       external: externalDeps,
-      output: {
-        // Rolldown's ESM output for externals falls back to a `require()` that
-        // throws in environments without a global `require` (e.g. Vitest
-        // loading externalized deps via Node's native ESM loader) - some
-        // bundled runtime deps (focus-trap-react) are plain CJS and call
-        // require('react') internally. A real, working `require` bound to
-        // this module satisfies that fallback everywhere it's checked.
-        intro: "import { createRequire as __createRequire } from 'module';\nconst require = __createRequire(import.meta.url);",
-      },
     },
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,11 +34,11 @@ export default defineConfig({
       // focus-trap-react is plain CJS and does `require('react')` in its own
       // source to read React.version. 'react' is external here, and rolldown's
       // fallback for a require() targeting an external only works if a global
-      // `require` exists at runtime - true in Node's CJS mode, but not under
-      // native ESM loaders (Vitest) or in the browser (Next.js/webpack), where
-      // it either throws or fails to statically resolve. Converting this one
-      // known require() call to a real import at the source level means
-      // rolldown never needs that fallback for it at all.
+      // `require` exists at runtime - true in Node's CJS mode, but not when a
+      // downstream bundler (e.g. Turbopack) resolves this ESM output for a
+      // browser bundle, or when Vitest loads it via Node's native ESM loader.
+      // Converting this one known require() call to a real import at the
+      // source level means rolldown never needs that fallback for it at all.
       name: 'focus-trap-react-require-to-import',
       transform(code, id) {
         if (!id.includes('/focus-trap-react/')) return null;


### PR DESCRIPTION
**#290 (already published as 10.0.2) is currently broken for any consumer using a browser bundler** - Next.js/Turbopack (and presumably webpack) fail with `Module not found: Can't resolve 'module'` on every clib chunk. Confirmed via vm-web's real `next build`: worked fine on 10.0.0 (before #290), broke on 10.0.2 (after it).

Root cause of the regression: #290's fix injected `import { createRequire } from 'module'` via `output.intro` to give rolldown's require-fallback (for focus-trap-react's internal `require('react')`) something to satisfy its `typeof require !== 'undefined'` check. That works in Node (Vitest), but `module` is a Node built-in with no browser equivalent, and the intro gets injected into *every* output chunk, so any bundler resolving for the browser fails immediately.

Fix: drop the Node-only shim, replace with a targeted source transform. `react/jsx-runtime`/`react/jsx-dev-runtime` externalization from #290 was correct and is kept. The only remaining problem is `focus-trap-react`'s own literal `require('react')` in its source - converted to a proper `import React from 'react'` before rolldown ever bundles it, so rolldown never needs the require-fallback for it at all. Confirmed zero occurrences of the fallback pattern in the built dist now.

Verified against all three real scenarios this time, not just one in isolation:
- Vitest (via a `file:` dependency pointing at this branch's dist): passes.
- Real `next build` in vm-web with this dist swapped in: passes cleanly, no module-not-found errors.
- vm-web's own `tsc:no-emit` + full 364-test unit suite: all pass.

typecheck/lint/test/build/build-vercel all green in clib itself too.

This should probably go out as a patch once merged, same as 10.0.1/10.0.2 - no new dependency bump, just fixing what #290 broke.
